### PR TITLE
Make Google Play filters runnable in browser

### DIFF
--- a/declarations/Google Play.filters.js
+++ b/declarations/Google Play.filters.js
@@ -1,8 +1,6 @@
-import DataURIParser from 'datauri/parser.js';
 import fetch from 'isomorphic-fetch';
 import mime from 'mime';
 
-const dataURI = new DataURIParser();
 
 export async function downloadImages(document, { fetch: baseUrl, select: selector }) {
   const images = Array.from(document.querySelectorAll(`${selector} img`));
@@ -18,6 +16,7 @@ export async function downloadImages(document, { fetch: baseUrl, select: selecto
     const content = await response.arrayBuffer();
     const extension = mime.getExtension(mimeType);
 
-    images[index].src = dataURI.format(extension, content).content;
+    const base64Content = btoa(String.fromCharCode(...new Uint8Array(content)));
+    images[index].src = `data:${mimeType};base64,${base64Content}`;
   }));
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
     "open-terms-archive": "git+https://git@github.com/ambanum/OpenTermsArchive#main"
   },
   "dependencies": {
-    "datauri": "^4.1.0",
-    "mime": "^3.0.0",
-    "isomorphic-fetch": "^3.0.0"
+    "isomorphic-fetch": "^3.0.0",
+    "mime": "^3.0.0"
   }
 }


### PR DESCRIPTION
The previously used `DataURIParser` is very difficult to get to transpile to browser JS. I tried with both `rollup` and `browserify` setups without any luck.

It seems this package provides little to no addition to a few lines of vanilla JS to handle the data-URI formatting.

Here is a replacement proposal.