### PR TITLE
Remove Intagram url param that caused blinking

### DIFF
--- a/declarations/Instagram.filters.js
+++ b/declarations/Instagram.filters.js
@@ -15,5 +15,9 @@ export function removeTrackingIDs(document) {
       params.set('h', 'removed');
       el.setAttribute('href', params.toString());
     }
+    if (params.has('e')) {
+      params.set('e', 'removed');
+      el.setAttribute('href', params.toString());
+    }
   });
 }


### PR DESCRIPTION
To remove the blinking on 
- [Law Enforcement Guidelines](https://github.com/OpenTermsArchive/contrib-versions/commits/main/Instagram/Law%20Enforcement%20Guidelines.md)
- [Community Guidelines](https://github.com/OpenTermsArchive/contrib-versions/commit/526fc195c139ee739e1aa3903ad57c78ea6510ff)
- [Terms of Service](https://github.com/OpenTermsArchive/contrib-versions/commit/11d840df5cbb3d13a3ee81f05b487babd0f476b6)