### PR TITLE
Add PayPal service with subset of available documents

### DIFF
--- a/declarations/PayPal.json
+++ b/declarations/PayPal.json
@@ -1,0 +1,145 @@
+{
+  "name": "PayPal",
+  "documents": {
+    "User Agreement (United Kingdom, EN)": {
+      "fetch": "https://www.paypal.com/uk/webapps/mpp/ua/useragreement-full?locale.x=en_GB",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "Privacy Statement (United Kingdom, EN)": {
+      "fetch": "https://www.paypal.com/uk/webapps/mpp/ua/privacy-full?locale.x=en_GB",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "User Agreement (France, EN)": {
+      "fetch": "https://www.paypal.com/fr/webapps/mpp/ua/useragreement-full?locale.x=en_FR",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "Privacy Statement (France, FR)": {
+      "fetch": "https://www.paypal.com/fr/webapps/mpp/ua/privacy-full?locale.x=fr_FR",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "Conditions d'utilisation (France, FR)": {
+      "fetch": "https://www.paypal.com/fr/webapps/mpp/ua/useragreement-full?locale.x=fr_FR",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "Politique de confidentialité (France, EN)": {
+      "fetch": "https://www.paypal.com/fr/webapps/mpp/ua/privacy-full?locale.x=en_FR",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "User Agreement (Germany, EN)": {
+      "fetch": "https://www.paypal.com/de/webapps/mpp/ua/useragreement-full?locale.x=en_DE",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "Privacy Statement (Germany, EN)": {
+      "fetch": "https://www.paypal.com/de/webapps/mpp/ua/privacy-full?locale.x=en_DE",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "Nutzungsbedingungen (Deutschland, DE)": {
+      "fetch": "https://www.paypal.com/de/webapps/mpp/ua/useragreement-full?locale.x=de_DE",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "Datenschutzerklärung (Deutschland, DE)": {
+      "fetch": "https://www.paypal.com/de/webapps/mpp/ua/privacy-full?locale.x=de_DE",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "User Agreement (European Union, EN)": {
+      "fetch": "https://www.paypal.com/cz/webapps/mpp/ua/useragreement-full?locale.x=en_CZ",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "Privacy Statement (European Union, EN)": {
+      "fetch": "https://www.paypal.com/cz/webapps/mpp/ua/privacy-full?locale.x=en_CZ",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "User Agreement (European Union - Send Only, EN)": {
+      "fetch": "https://www.paypal.com/va/webapps/mpp/ua/useragreement-full?locale.x=en_VA",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    },
+    "Privacy Statement (European Union - Send Only, EN)": {
+      "fetch": "https://www.paypal.com/va/webapps/mpp/ua/privacy-full?locale.x=en_VA",
+      "select": [
+        "#main .containerCentered"
+      ],
+      "remove": [
+        "#ua_skinny_view",
+        ".containerCentered > p:nth-child(1)"
+      ]
+    }
+  }
+}

--- a/declarations/PayPal.json
+++ b/declarations/PayPal.json
@@ -1,7 +1,7 @@
 {
   "name": "PayPal",
   "documents": {
-    "User Agreement (United Kingdom, EN)": {
+    "Terms of Service (United Kingdom, EN)": {
       "fetch": "https://www.paypal.com/uk/webapps/mpp/ua/useragreement-full?locale.x=en_GB",
       "select": [
         "#main .containerCentered"
@@ -11,7 +11,7 @@
         ".containerCentered > p:nth-child(1)"
       ]
     },
-    "Privacy Statement (United Kingdom, EN)": {
+    "Privacy Policy (United Kingdom, EN)": {
       "fetch": "https://www.paypal.com/uk/webapps/mpp/ua/privacy-full?locale.x=en_GB",
       "select": [
         "#main .containerCentered"
@@ -21,7 +21,7 @@
         ".containerCentered > p:nth-child(1)"
       ]
     },
-    "User Agreement (France, EN)": {
+    "Terms of Service (France, EN)": {
       "fetch": "https://www.paypal.com/fr/webapps/mpp/ua/useragreement-full?locale.x=en_FR",
       "select": [
         "#main .containerCentered"
@@ -31,7 +31,7 @@
         ".containerCentered > p:nth-child(1)"
       ]
     },
-    "Privacy Statement (France, FR)": {
+    "Privacy Policy (France, FR)": {
       "fetch": "https://www.paypal.com/fr/webapps/mpp/ua/privacy-full?locale.x=fr_FR",
       "select": [
         "#main .containerCentered"
@@ -61,7 +61,7 @@
         ".containerCentered > p:nth-child(1)"
       ]
     },
-    "User Agreement (Germany, EN)": {
+    "Terms of Service (Germany, EN)": {
       "fetch": "https://www.paypal.com/de/webapps/mpp/ua/useragreement-full?locale.x=en_DE",
       "select": [
         "#main .containerCentered"
@@ -71,7 +71,7 @@
         ".containerCentered > p:nth-child(1)"
       ]
     },
-    "Privacy Statement (Germany, EN)": {
+    "Privacy Policy (Germany, EN)": {
       "fetch": "https://www.paypal.com/de/webapps/mpp/ua/privacy-full?locale.x=en_DE",
       "select": [
         "#main .containerCentered"
@@ -101,7 +101,7 @@
         ".containerCentered > p:nth-child(1)"
       ]
     },
-    "User Agreement (European Union, EN)": {
+    "Terms of Service (European Union, EN)": {
       "fetch": "https://www.paypal.com/cz/webapps/mpp/ua/useragreement-full?locale.x=en_CZ",
       "select": [
         "#main .containerCentered"
@@ -111,7 +111,7 @@
         ".containerCentered > p:nth-child(1)"
       ]
     },
-    "Privacy Statement (European Union, EN)": {
+    "Privacy Policy (European Union, EN)": {
       "fetch": "https://www.paypal.com/cz/webapps/mpp/ua/privacy-full?locale.x=en_CZ",
       "select": [
         "#main .containerCentered"
@@ -121,7 +121,7 @@
         ".containerCentered > p:nth-child(1)"
       ]
     },
-    "User Agreement (European Union - Send Only, EN)": {
+    "Terms of Service (European Union - Send Only, EN)": {
       "fetch": "https://www.paypal.com/va/webapps/mpp/ua/useragreement-full?locale.x=en_VA",
       "select": [
         "#main .containerCentered"
@@ -131,7 +131,7 @@
         ".containerCentered > p:nth-child(1)"
       ]
     },
-    "Privacy Statement (European Union - Send Only, EN)": {
+    "Privacy Policy (European Union - Send Only, EN)": {
       "fetch": "https://www.paypal.com/va/webapps/mpp/ua/privacy-full?locale.x=en_VA",
       "select": [
         "#main .containerCentered"


### PR DESCRIPTION
The Legal Agreements page has various location and languages for selection.

Each links to various legal documents.

The User Agreement and Privacy Statement seem like the most important documents, so a good starting point to add declarations for.

Given the US market/user size, en_US would be important too, but has different HTML document structure, so is left out of this initial addition.

EU, FR, DE are added as a subset selection over other available locations and languages due to their market/user significance.

Replaces #695
_(Partially?)_ Implements/Resolves #50 and #51