### PR TITLE
Update PayPal privacy policy from FR FR to EU EN (through CZ EN)

### DIFF
--- a/declarations/PayPal.json
+++ b/declarations/PayPal.json
@@ -2,7 +2,7 @@
   "name": "PayPal",
   "documents": {
     "Privacy Policy": {
-      "fetch": "https://www.paypal.com/fr/webapps/mpp/ua/privacy-full",
+      "fetch": "https://www.paypal.com/cz/webapps/mpp/ua/privacy-full?locale.x=en_CZ",
       "select": [
         {
           "startBefore": "h1",


### PR DESCRIPTION
The PayPal legal hub page [1] has a location + language selection dropdown. Selecting “European Union (in English)” links to the cz “location”, and en_CZ locale.

While explicitly referring to the CZ location and locale seems wrong when we want to refer to EU, given that the dropdown menu explicitly links EU to CZ we have to assume that CZ is neutral at least so far that it matches the general EU rules.  
Given no direct linking, we can not necessarily make such an assumption for other EU locations, or that it stays that way.

Followup to #695 (c74a4c8)
Closes #51
Related #696 (various PayPal documents, locations and locales)

[1] https://www.paypal.com/cz/webapps/mpp/ua/legalhub-full?locale.x=en_CZ