### PR TITLE
Fix OTA scripts as there was an error on merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # fetch all history for all branches and tags
-      - run: git branch main remotes/origin/main
       - uses: actions/setup-node@v2
         with:
           node-version: 16


### PR DESCRIPTION
This will update to the latest version of `open-terms-archive` package and fix the [problem when merging on main](https://github.com/OpenTermsArchive/contrib-declarations/actions/runs/3436321654)