### PR TITLE
Fix Palantir declarations

### DIFF
--- a/declarations/Palantir.json
+++ b/declarations/Palantir.json
@@ -4,24 +4,21 @@
     "Terms of Service": {
       "fetch": "https://www.palantir.com/terms-and-conditions/",
       "select": [
-        ".design__heading__j18gsz",
-        ".design__text200__1xw780a"
+        "main section"
       ],
       "executeClientScripts": true
     },
     "Privacy Policy": {
       "fetch": "https://www.palantir.com/privacy-and-security/",
       "select": [
-        ".design__heading__j18gsz",
-        ".design__text200__1xw780a"
+        "main section"
       ],
       "executeClientScripts": true
     },
     "Trackers Policy": {
       "fetch": "https://www.palantir.com/cookie-statement/",
       "select": [
-        ".design__heading__j18gsz",
-        ".design__text__1xw780a"
+        "main section"
       ],
       "executeClientScripts": true
     }


### PR DESCRIPTION
Fixes #37, #38, #39

---

The links in the bot-created tickets are outdated. The contribute tool fails to display the fetched page. (Is there another issue with executing the client scripts?) The previous selectors with generated ids became obsolete. The new `main section` selector will be more stable.