### PR TITLE
Use branches-ignore pattern as ! pattern does not launch action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,8 @@ name: Validate declarations
 
 on:
   push:
-    branches: 
-      - '!main'
+    branches-ignore:
+      - 'main'
   pull_request:
     types: [ opened, reopened ]
   workflow_call:


### PR DESCRIPTION
Follow up on [change deployment PR](https://github.com/OpenTermsArchive/contrib-declarations/pull/748), the `!` pattern seems to [not launch correctly](https://github.com/OpenTermsArchive/contrib-declarations/pull/748/checks) the checks.

So fallback to the `branches-ignore` pattern[ which works](https://github.com/OpenTermsArchive/contrib-declarations/pull/776/checks)