### PR TITLE
Update WebProNews ToS and PP declarations

### DIFF
--- a/declarations/WebProNews.history.json
+++ b/declarations/WebProNews.history.json
@@ -4,6 +4,11 @@
       "fetch": "https://www.webpronews.com/terms-of-service/",
       "select": "body",
       "validUntil": "2020-12-08T16:00:00.000Z"
+    },
+    {
+      "fetch": "https://www.webpronews.com/terms-of-service/",
+      "select": "[role=main]",
+      "validUntil": "2023-10-18T15:11:54Z"
     }
   ],
   "Privacy Policy": [
@@ -11,6 +16,11 @@
       "fetch": "https://www.webpronews.com/privacy-policy/",
       "select": "body",
       "validUntil": "2020-12-08T16:00:00.000Z"
+    },
+    {
+      "fetch": "https://www.webpronews.com/privacy-policy/",
+      "select": "[role=main]",
+      "validUntil": "2023-10-18T15:11:54Z"
     }
   ]
 }

--- a/declarations/WebProNews.json
+++ b/declarations/WebProNews.json
@@ -5,12 +5,32 @@
     "Terms of Service": {
       "fetch": "https://www.webpronews.com/terms-of-service/",
       "select": "body.page",
-      "remove": [".header-top", ".header", ".overlay-menu", ".home-nl-bar", ".pop-media-kit", ".chat-bubble", ".footer", "#mediakit", "#mymodal"]
+      "remove": [
+        ".header-top",
+        ".header",
+        ".overlay-menu",
+        ".home-nl-bar",
+        ".pop-media-kit",
+        ".chat-bubble",
+        ".footer",
+        "#mediakit",
+        "#mymodal"
+      ]
     },
     "Privacy Policy": {
       "fetch": "https://www.webpronews.com/privacy-policy/",
       "select": "body.page",
-      "remove": [".header-top", ".header", ".overlay-menu", ".home-nl-bar", ".pop-media-kit", ".chat-bubble", ".footer", "#mediakit", "#mymodal"]
+      "remove": [
+        ".header-top",
+        ".header",
+        ".overlay-menu",
+        ".home-nl-bar",
+        ".pop-media-kit",
+        ".chat-bubble",
+        ".footer",
+        "#mediakit",
+        "#mymodal"
+      ]
     }
   }
 }

--- a/declarations/WebProNews.json
+++ b/declarations/WebProNews.json
@@ -4,11 +4,13 @@
   "documents": {
     "Terms of Service": {
       "fetch": "https://www.webpronews.com/terms-of-service/",
-      "select": "[role=main]"
+      "select": "body.page",
+      "remove": [".header-top", ".header", ".overlay-menu", ".home-nl-bar", ".pop-media-kit", ".chat-bubble", ".footer", "#mediakit", "#mymodal"]
     },
     "Privacy Policy": {
       "fetch": "https://www.webpronews.com/privacy-policy/",
-      "select": "[role=main]"
+      "select": "body.page",
+      "remove": [".header-top", ".header", ".overlay-menu", ".home-nl-bar", ".pop-media-kit", ".chat-bubble", ".footer", "#mediakit", "#mymodal"]
     }
   }
 }


### PR DESCRIPTION
There is no good narrow selector for the page content. `.container` and `.row` are used in the neighboring blocks too.

Using `body.page` instead of merely `body` or `page` will protect against a systematic DOM structure change.

Use a broad page selecting, and remove all neighboring blocks.

Fixes #1136 and #1137