### PR TITLE
Add 'Alpha Vantage' ToS and PP declarations

### DIFF
--- a/declarations/Alpha Vantage.json
+++ b/declarations/Alpha Vantage.json
@@ -1,0 +1,11 @@
+{
+  "name": "Alpha Vantage",
+  "documents": {
+    "Terms of Service": {
+      "fetch": "https://www.alphavantage.co/terms_of_service/?.pdf"
+    },
+    "Privacy Policy": {
+      "fetch": "https://www.alphavantage.co/privacy/?.pdf"
+    }
+  }
+}


### PR DESCRIPTION
Both URLs respond with a PDF response => no selectors

Uses `?.pdf` as a workaround for lint not supporting arbitrary URLs for PDFs

https://github.com/OpenTermsArchive/engine/issues/900
