### PR TITLE
Track Telegram FAQ and additional terms

### DIFF
--- a/declarations/Telegram.json
+++ b/declarations/Telegram.json
@@ -18,12 +18,8 @@
       "fetch": "https://telegram.org/faq?setln=en",
       "select": [
         {
-          "startBefore": "h4:has(> [name=q-who-are-the-people-behind-telegram])",
-          "endBefore": "h4:has(> [name=q-who-are-the-people-behind-telegram]) + h4"
-        },
-        {
-          "startBefore": "h4:has(> [name=q-where-is-telegram-based])",
-          "endBefore": "h4:has(> [name=q-where-is-telegram-based]) + h4"
+          "startBefore": "[name=q-who-are-the-people-behind-telegram]",
+          "endBefore": "[name=q-will-you-have-ads-in-my-private-chats-and-groups-or-sell-my-da]"
         }
       ]
     },
@@ -33,17 +29,7 @@
     },
     "Community Guidelines": {
       "fetch": "https://telegram.org/tos/eu-dsa?setln=en",
-      "select": ".tl_page_container",
-      "remove": [
-        {
-          "startBefore": "h4:has(> [name=contact-points-for-competent-authorities-in-eu-countries])",
-          "endBefore": "h4:has(> [name=contact-points-for-competent-authorities-in-eu-countries]) + h4"
-        },
-        {
-          "startBefore": "h4:has(> [name=average-monthly-active-recipients-of-service-in-the-eu])",
-          "endBefore": "h4:has(> [name=average-monthly-active-recipients-of-service-in-the-eu]) + h4"
-        }
-      ]
+      "select": ".tl_page_container"
     },
     "Law Enforcement Guidelines": {
       "combine": [
@@ -51,8 +37,8 @@
           "fetch": "https://telegram.org/tos/eu-dsa?setln=en",
           "select": [
             {
-              "startBefore": "h4:has(> [name=contact-points-for-competent-authorities-in-eu-countries]",
-              "endBefore": "h4:has(> [name=contact-points-for-competent-authorities-in-eu-countries]) + h4"
+              "startBefore": "[name=contact-points-for-competent-authorities-in-eu-countries]",
+              "endBefore": "[name=average-monthly-active-recipients-of-service-in-the-eu]"
             }
           ]
         },
@@ -60,10 +46,11 @@
           "fetch": "https://telegram.org/faq?setln=en",
           "select": [
             {
-              "startBefore": "h4:has(> [name=q-do-you-process-data-requests])",
-              "endBefore": "h4:has(> [name=q-do-you-process-data-requests]) + h4"
+              "startBefore": "[name=q-do-you-process-data-requests]",
+              "endBefore": "[name=telegram-basics]"
             }
-          ]
+          ],
+          "remove": "blockquote"
         }
       ]
     },
@@ -71,8 +58,8 @@
       "fetch": "https://telegram.org/faq?setln=en",
       "select": [
         {
-          "startBefore": "h4:has(> [name=q-a-bot-or-channel-is-infringing-on-my-copyright-what-do-i-do])",
-          "endBefore": "h4:has(> [name=q-a-bot-or-channel-is-infringing-on-my-copyright-what-do-i-do]) + h4"
+          "startBefore": "[name=q-a-bot-or-channel-is-infringing-on-my-copyright-what-do-i-do]",
+          "endBefore": "[name=q-do-you-process-take-down-requests-from-third-parties]"
         }
       ]
     },
@@ -80,17 +67,8 @@
       "fetch": "https://telegram.org/faq?setln=en",
       "select": [
         {
-          "startBefore": "h4:has(> [name=passport])",
-          "endBefore": "h4:has(> [name=passport]) + h4"
-        }
-      ]
-    },
-    "Complaints Policy": {
-      "fetch": "https://telegram.org/faq?setln=en",
-      "select": [
-        {
-          "startBefore": "h4:has(> [name=q-do-you-process-take-down-requests-from-third-parties])",
-          "endBefore": "h4:has(> [name=q-do-you-process-take-down-requests-from-third-parties]) + h4"
+          "startBefore": "[name=passport]",
+          "endBefore": "[name=troubleshooting]"
         }
       ]
     }

--- a/declarations/Telegram.json
+++ b/declarations/Telegram.json
@@ -13,6 +13,86 @@
       "fetch": "https://core.telegram.org/api/terms",
       "select": "#dev_page_content_wrap",
       "remove": ".breadcrumb"
+    },
+    "Imprint": {
+      "fetch": "https://telegram.org/faq?setln=en",
+      "select": [
+        {
+          "startBefore": "h4:has(> [name=q-who-are-the-people-behind-telegram])",
+          "endBefore": "h4:has(> [name=q-who-are-the-people-behind-telegram]) + h4"
+        },
+        {
+          "startBefore": "h4:has(> [name=q-where-is-telegram-based])",
+          "endBefore": "h4:has(> [name=q-where-is-telegram-based]) + h4"
+        }
+      ]
+    },
+    "Vulnerability Disclosure Policy": {
+      "fetch": "https://core.telegram.org/bug-bounty",
+      "select": ".dev_page"
+    },
+    "Community Guidelines": {
+      "fetch": "https://telegram.org/tos/eu-dsa?setln=en",
+      "select": ".tl_page_container",
+      "remove": [
+        {
+          "startBefore": "h4:has(> [name=contact-points-for-competent-authorities-in-eu-countries])",
+          "endBefore": "h4:has(> [name=contact-points-for-competent-authorities-in-eu-countries]) + h4"
+        },
+        {
+          "startBefore": "h4:has(> [name=average-monthly-active-recipients-of-service-in-the-eu])",
+          "endBefore": "h4:has(> [name=average-monthly-active-recipients-of-service-in-the-eu]) + h4"
+        }
+      ]
+    },
+    "Law Enforcement Guidelines": {
+      "combine": [
+        {
+          "fetch": "https://telegram.org/tos/eu-dsa?setln=en",
+          "select": [
+            {
+              "startBefore": "h4:has(> [name=contact-points-for-competent-authorities-in-eu-countries]",
+              "endBefore": "h4:has(> [name=contact-points-for-competent-authorities-in-eu-countries]) + h4"
+            }
+          ]
+        },
+        {
+          "fetch": "https://telegram.org/faq?setln=en",
+          "select": [
+            {
+              "startBefore": "h4:has(> [name=q-do-you-process-data-requests])",
+              "endBefore": "h4:has(> [name=q-do-you-process-data-requests]) + h4"
+            }
+          ]
+        }
+      ]
+    },
+    "Copyright Claims Policy": {
+      "fetch": "https://telegram.org/faq?setln=en",
+      "select": [
+        {
+          "startBefore": "h4:has(> [name=q-a-bot-or-channel-is-infringing-on-my-copyright-what-do-i-do])",
+          "endBefore": "h4:has(> [name=q-a-bot-or-channel-is-infringing-on-my-copyright-what-do-i-do]) + h4"
+        }
+      ]
+    },
+    "Single Sign-On Policy": {
+      "fetch": "https://telegram.org/faq?setln=en",
+      "select": [
+        {
+          "startBefore": "h4:has(> [name=passport])",
+          "endBefore": "h4:has(> [name=passport]) + h4"
+        }
+      ]
+    },
+    "Complaints Policy": {
+      "fetch": "https://telegram.org/faq?setln=en",
+      "select": [
+        {
+          "startBefore": "h4:has(> [name=q-do-you-process-take-down-requests-from-third-parties])",
+          "endBefore": "h4:has(> [name=q-do-you-process-take-down-requests-from-third-parties]) + h4"
+        }
+      ]
     }
   }
 }

--- a/declarations/Telegram.json
+++ b/declarations/Telegram.json
@@ -3,11 +3,11 @@
   "documents": {
     "Privacy Policy": {
       "fetch": "https://telegram.org/privacy",
-      "select": "#dev_page_content_wrap"
+      "select": ".tl_page_container"
     },
     "Terms of Service": {
       "fetch": "https://telegram.org/tos",
-      "select": "#dev_page_content_wrap"
+      "select": ".tl_page_container"
     },
     "Developer Terms": {
       "fetch": "https://core.telegram.org/api/terms",

--- a/declarations/Telegram.json
+++ b/declarations/Telegram.json
@@ -6,8 +6,20 @@
       "select": ".tl_page_container"
     },
     "Terms of Service": {
-      "fetch": "https://telegram.org/tos",
-      "select": ".tl_page_container"
+      "combine": [
+        {
+          "fetch": "https://telegram.org/tos",
+          "select": ".tl_page_container"
+        },
+        {
+          "fetch": "https://telegram.org/faq?setln=en",
+          "select": ".tl_page_container",
+          "remove": [
+            "img",
+            "video"
+          ]
+        }
+      ]
     },
     "Developer Terms": {
       "fetch": "https://core.telegram.org/api/terms",


### PR DESCRIPTION
- Add Telegram Imprint
- Add Telegram Vulnerability Disclosure Policy
- Add Telegram Community Guidelines
- Add Telegram Law Enforcement Guidelines
- Add Telegram Copyright Claims Policy
- Add Telegram Single Sign-On Policy
- Add Telegram Complaints Policy

- - -

Telegram has an unusual layout for its terms. It has dedicated ToS and PP pages, but describes most of its other commitments in a single FAQ, laying out side by side technical, commercial and legal information. This PR implements tracking by identifying specific terms types in rather brittle selectors (as each relies on two named titles), and adds a “catch-all” safety net on the ToS, combining them with the whole FAQ.

The history is not edited as this could have been tracked in the suggested way from the beginning.