### PR TITLE
Update GitHub artifact actions to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Generate artifacts
         if: ${{ failure() }}
         run: npm run start:modified
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: snapshots_and_versions


### PR DESCRIPTION
Starting December 5, 2024, GitHub Actions customers [will no longer be able to use v3](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) of [actions/upload-artifact](https://github.com/actions/upload-artifact).