### PR TITLE
Fix Wikipedia blinking

### DIFF
--- a/declarations/Wikipedia.history.json
+++ b/declarations/Wikipedia.history.json
@@ -4,6 +4,20 @@
       "fetch": "https://foundation.wikimedia.org/wiki/Privacy_policy",
       "select": "body",
       "validUntil": "2020-11-09T17:30:03.000Z"
+    },
+    {
+      "fetch": "https://foundation.wikimedia.org/wiki/Privacy_policy",
+      "select": [
+        "#firstHeading",
+        "#mw-content-text"
+      ],
+      "remove": [
+        ".divlang",
+        "table.collapsible.collapsed",
+        "#catlinks",
+        ".nomobile"
+      ],
+      "validUntil": "2024-05-25T18:47:32.000Z"
     }
   ],
   "Terms of Service": [
@@ -11,6 +25,12 @@
       "fetch": "https://foundation.wikimedia.org/wiki/Terms_of_Use",
       "select": "body",
       "validUntil": "2020-11-09T17:30:03.000Z"
+    },
+    {
+      "fetch": "https://foundation.wikimedia.org/wiki/Terms_of_Use",
+      "select": "#content",
+      "remove": ".nmbox, #toc",
+      "validUntil": "2024-05-25T18:47:33.000Z"
     }
   ]
 }

--- a/declarations/Wikipedia.json
+++ b/declarations/Wikipedia.json
@@ -4,13 +4,28 @@
   "documents": {
     "Privacy Policy": {
       "fetch": "https://foundation.wikimedia.org/wiki/Privacy_policy",
-      "select": "#firstHeading, #mw-content-text",
-      "remove": ".divlang, table.collapsible.collapsed, #catlinks, .nomobile"
+      "select": [
+        "#firstHeading",
+        "#mw-content-text"
+      ],
+      "remove": [
+        "a[title]",
+        ".divlang",
+        "table.collapsible.collapsed",
+        "#catlinks",
+        ".nomobile"
+      ]
     },
     "Terms of Service": {
       "fetch": "https://foundation.wikimedia.org/wiki/Terms_of_Use",
-      "select": "#content",
-      "remove": ".nmbox, #toc"
+      "select": [
+        "#content"
+      ],
+      "remove": [
+        "a[title]",
+        ".nmbox",
+        "#toc"
+      ]
     }
   }
 }


### PR DESCRIPTION
I am attempting to clean up some of these blinking versions and I noticed that both the TOS and PP for Wikipedia have been blinking for some time. I fixed this by removing the "%" in the translated language section since it changes every time OTA scrapes those pages. 

I was not sure how I should label the `validUntil`  in the history for each but these are the first versions that showed these blinks:
- TOS: https://github.com/OpenTermsArchive/contrib-versions/commit/726c458a6ac7033d2d8dc25968d9ca92c39114c4
- PP: https://github.com/OpenTermsArchive/contrib-versions/commit/4c74db52c91a77d9b1139bcfb07160c76e2bc573
