### PR TITLE
Add validUntil datetime for https://www.usa.gov/policies

### DIFF
--- a/declarations/USA.gov.history.json
+++ b/declarations/USA.gov.history.json
@@ -8,7 +8,7 @@
     {
       "fetch": "https://www.usa.gov/policies",
       "select": ".rightnav",
-      "validUntil": "to-be-determined"
+      "validUntil": "2023-10-18T15:11:16Z"
     }
   ]
 }


### PR DESCRIPTION
Adds in the `validUntil` as described in: https://github.com/OpenTermsArchive/contrib-declarations/issues/1127