### PR TITLE
Update coindesk ToS selector

### DIFF
--- a/declarations/Coindesk.history.json
+++ b/declarations/Coindesk.history.json
@@ -1,0 +1,9 @@
+{
+  "Terms of Service": [
+    {
+      "fetch": "https://www.coindesk.com/terms/",
+      "select": "main",
+      "validUntil": "2024-11-25T06:03:31.000Z"
+    }
+  ]
+}

--- a/declarations/Coindesk.json
+++ b/declarations/Coindesk.json
@@ -4,7 +4,7 @@
     "Terms of Service": {
       "fetch": "https://www.coindesk.com/terms/",
       "select": [
-        "main"
+        ".flex-grow"
       ]
     },
     "Privacy Policy": {

--- a/declarations/Coindesk.json
+++ b/declarations/Coindesk.json
@@ -4,7 +4,7 @@
     "Terms of Service": {
       "fetch": "https://www.coindesk.com/terms/",
       "select": [
-        ".flex-grow"
+        "[data-module-name=\"page\"]"
       ]
     },
     "Privacy Policy": {


### PR DESCRIPTION
I updated Coindesk Terms of Service selectors to reduce cases of blinking in tracking changes. I have not included a history.json file since I am not sure how to get the valid until date, as it is supposed to be the last snapshot time and date, but this service continues its tracking. Maybe you can provide more direction here