### PR TITLE
Update Coindesk Privacy Policy selector

### DIFF
--- a/declarations/Coindesk.history.json
+++ b/declarations/Coindesk.history.json
@@ -5,5 +5,12 @@
       "select": "main",
       "validUntil": "2024-11-25T06:03:31.000Z"
     }
+  ],
+  "Privacy Policy": [
+    {
+      "fetch": "https://www.coindesk.com/privacy/",
+      "select": "main",
+      "validUntil": "2024-11-25T06:03:31.000Z"
+    }
   ]
 }

--- a/declarations/Coindesk.json
+++ b/declarations/Coindesk.json
@@ -10,7 +10,7 @@
     "Privacy Policy": {
       "fetch": "https://www.coindesk.com/privacy/",
       "select": [
-        ".flex-grow"
+        "[data-module-name=\"page\"]"
       ]
     },
     "Editorial Policy": {

--- a/declarations/Coindesk.json
+++ b/declarations/Coindesk.json
@@ -10,7 +10,7 @@
     "Privacy Policy": {
       "fetch": "https://www.coindesk.com/privacy/",
       "select": [
-        "main"
+        ".flex-grow"
       ]
     },
     "Editorial Policy": {


### PR DESCRIPTION
I have updated the Coindesk Privacy policy selector to reduce blinking instances in the tracking.

Note: In didn't add the history file as I don't know how to get the validUntil date