### PR TITLE
Update Coindesk Editorial Policy selector

### DIFF
--- a/declarations/Coindesk.history.json
+++ b/declarations/Coindesk.history.json
@@ -12,5 +12,12 @@
       "select": "main",
       "validUntil": "2024-11-25T06:03:31.000Z"
     }
+  ],
+  "Editorial Policy": [
+    {
+      "fetch": "https://www.coindesk.com/ethics/",
+      "select": "main",
+      "validUntil": "2024-11-25T06:03:32.000Z"
+    }
   ]
 }

--- a/declarations/Coindesk.json
+++ b/declarations/Coindesk.json
@@ -16,7 +16,7 @@
     "Editorial Policy": {
       "fetch": "https://www.coindesk.com/ethics/",
       "select": [
-        ".flex-grow"
+        "[data-module-name=\"page\"]"
       ]
     }
   }

--- a/declarations/Coindesk.json
+++ b/declarations/Coindesk.json
@@ -16,7 +16,7 @@
     "Editorial Policy": {
       "fetch": "https://www.coindesk.com/ethics/",
       "select": [
-        "main"
+        ".flex-grow"
       ]
     }
   }


### PR DESCRIPTION
Updated the selector to reduce instances of blinking in the tracking

Note: I haven't added history file as I am unsure in how to best get the validUntil date