### PR TITLE
Terminate Lydia service

### DIFF
--- a/declarations/Lydia.history.json
+++ b/declarations/Lydia.history.json
@@ -1,0 +1,24 @@
+{
+  "Privacy Policy": [
+    {
+      "fetch": "https://support.lydia-app.com/l/en/article/6ogzqxbjos-lydia-personal-data-protection-policy",
+      "select": [
+        ".card-block:nth-child(1)"
+      ],
+      "remove": [
+        ".meta"
+      ],
+      "validUntil": "2021-10-27T14:36:00Z"
+    }
+  ],
+  "Terms of Service": [
+    {
+      "fetch": "https://lydia-app.com/ie/info/terms-of-service.html",
+      "select": [
+        ".centered-v",
+        ".white"
+      ],
+      "validUntil": "2022-06-14T14:36:00Z"
+    }
+  ]
+}

--- a/declarations/Lydia.json
+++ b/declarations/Lydia.json
@@ -1,21 +1,4 @@
 {
   "name": "Lydia",
-  "terms": {
-    "Terms of Service": {
-      "fetch": "https://lydia-app.com/ie/info/terms-of-service.html",
-      "select": [
-        ".centered-v",
-        ".white"
-      ]
-    },
-    "Privacy Policy": {
-      "fetch": "https://support.lydia-app.com/l/en/article/6ogzqxbjos-lydia-personal-data-protection-policy",
-      "select": [
-        ".card-block:nth-child(1)"
-      ],
-      "remove": [
-        ".meta"
-      ]
-    }
-  }
+  "terms": {}
 }


### PR DESCRIPTION
Lydia split into different brands. Seemingly, the Lydia product no longer exists. Sumeria seems to offer a different product called Lydia jackpot or Lydia Paucebook, which is different from the payment app before.

contrib-versions shows Terms broke on 2021-10-27
https://github.com/OpenTermsArchive/contrib-versions/commit/33b5a72eb41f4d756c1c85b3962bcc180f9bc394

Resolves #1290
Resolves #1310

https://techcrunch.com/2024/05/15/lydia-the-french-social-payment-app-with-8-million-users-launches-mobile-banking-app-sumeria/