### PR TITLE
Add Min Myndighetspost

### DIFF
--- a/declarations/Min Myndighetspost.json
+++ b/declarations/Min Myndighetspost.json
@@ -1,0 +1,12 @@
+{
+  "name": "Min Myndighetspost",
+  "terms": {
+    "Terms of Service": {
+      "fetch": "https://minmyndighetspost.se/omminmyndighetspost/anvandarvillkorforminmyndighetspost.html",
+      "select": [
+        ".sv-column-7"
+      ],
+      "executeClientScripts": true
+    }
+  }
+}


### PR DESCRIPTION
[Min Myndighetspost](https://minmyndighetspost.se) is a Swedish digital post service used by 11% of the population. It's a product of the Swedish digital agency and a public alternative to the market leader Kivra (#3898).

The privacy policy seems to be included in the terms and conditions.