### PR TITLE
Add Freja eID

### DIFF
--- a/declarations/Freja eID.json
+++ b/declarations/Freja eID.json
@@ -1,0 +1,26 @@
+{
+  "name": "Freja eID",
+  "terms": {
+    "Terms of Service": {
+      "fetch": "https://frejaeid.com/en/terms-and-conditions/",
+      "select": [
+        "main"
+      ],
+      "executeClientScripts": true
+    },
+    "Privacy Policy": {
+      "fetch": "https://frejaeid.com/en/privacy-policy/",
+      "select": [
+        "main"
+      ],
+      "executeClientScripts": true
+    },
+    "Trackers Policy": {
+      "fetch": "https://org.frejaeid.com/en/cookie-policy/",
+      "select": [
+        "main"
+      ],
+      "executeClientScripts": true
+    }
+  }
+}


### PR DESCRIPTION
Freja eID is the official governmental eID in Sweden. Although it's only used by 4% of the population against the private BankID (92%, already added via #1476) ([source](https://svenskarnaochinternet.se/rapporter/svenskarna-och-internet-2024/e-tjanster/#e-legitimation-och-mobilt-bank-id)), it's worth adding as it will probably get more popular and be used in case of digital elections.