### PR TITLE
Add Skatteverket

### DIFF
--- a/declarations/Skatteverket.json
+++ b/declarations/Skatteverket.json
@@ -1,0 +1,21 @@
+{
+  "name": "Skatteverket",
+  "terms": {
+    "Privacy Policy": {
+      "fetch": "https://skatteverket.se/omoss/varverksamhet/behandlingavpersonuppgifter/behandlingavpersonuppgifterivaraetjanster.html",
+      "select": [
+        ".container"
+      ],
+      "remove": ".sv-skip-spacer",
+      "executeClientScripts": true
+    },
+    "Trackers Policy": {
+      "fetch": "https://skatteverket.se/omoss/varverksamhet/omwebbplatsen/kakorcookies.html",
+      "select": [
+        ".container"
+      ],
+      "remove": ".sv-skip-spacer",
+      "executeClientScripts": true
+    }
+  }
+}


### PR DESCRIPTION
Skatteverket is the Swedish tax agency. They are in charge of a large number of services available to the general public such as tax declaration and collection, census and birth certificate delivery, etc.

I could not find any terms of service but there was a page with a description of data processing for each service. There is also a [general page](https://skatteverket.se/omoss/varverksamhet/behandlingavpersonuppgifter.html) but I didn't add it since I didn't think it was as relevant.