### PR TITLE
Add Frank

### DIFF
--- a/declarations/Frank.json
+++ b/declarations/Frank.json
@@ -1,0 +1,23 @@
+{
+  "name": "Frank",
+  "terms": {
+    "Terms of Service": {
+      "fetch": "https://www.frank.fi/en/terms/",
+      "select": [
+        {
+          "startBefore": "hr ~ p",
+          "endBefore": "hr:nth-of-type(2)"
+        }
+      ]
+    },
+    "Privacy Policy": {
+      "fetch": "https://www.frank.fi/en/terms/",
+      "select": [
+        {
+          "startBefore": "hr:nth-of-type(2) ~ p",
+          "endBefore": "p[data-empty=\"true\"]"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Add Frank, which is the largest student ID provider in Finland