### PR TITLE
update proton mail

### DIFF
--- a/declarations/ProtonMail.json
+++ b/declarations/ProtonMail.json
@@ -1,16 +1,16 @@
 {
-  "name": "ProtonMail",
+  "name": "Proton Mail",
   "terms": {
     "Terms of Service": {
-      "fetch": "https://protonmail.com/terms-and-conditions",
+      "fetch": "https://proton.me/legal/terms",
       "select": [
-        ".content"
+        "main"
       ]
     },
     "Privacy Policy": {
-      "fetch": "https://protonmail.com/privacy-policy",
+      "fetch": "https://proton.me/legal/privacy",
       "select": [
-        ".content"
+        "main .rich-text"
       ]
     }
   }


### PR DESCRIPTION
The [contrib versions of Proton Mail](https://github.com/OpenTermsArchive/contrib-versions/tree/main/ProtonMail) are out of date because the endpoint of the Terms and Privacy Policy have changed.

(I am still unable to test locally but will check that asap)