### PR TITLE
Fix GitLab Privacy Policy

### DIFF
--- a/declarations/GitLab.filters.js
+++ b/declarations/GitLab.filters.js
@@ -14,8 +14,3 @@ export function removeCloudflareEmailProtection(document, possibleEmail) {
   document.body.innerHTML = document.body.innerHTML.replaceAll(possibleEmail, replaceWith);
   document.body.innerHTML = document.body.innerHTML.replaceAll(placeholder, possibleEmail.toLowerCase());
 }
-
-export function removeSecurityEmailProtection(document) {
-  removeCloudflareEmailProtection(document, 'security@gitlab.com');
-  removeCloudflareEmailProtection(document, 'Security@gitlab.com');
-}

--- a/declarations/GitLab.json
+++ b/declarations/GitLab.json
@@ -24,7 +24,12 @@
         ".breadcrumb"
       ],
       "filter": [
-        "removeSecurityEmailProtection"
+        {
+          "removeCloudflareEmailProtection": "security@gitlab.com"
+        },
+        {
+          "removeCloudflareEmailProtection": "Security@gitlab.com"
+        }
       ]
     },
     "Terms of Service": {


### PR DESCRIPTION
Should fix #1072. There was also a problem with email protection, sometimes it wasn't protected, sometimes Cloudflare protected it and sometimes GitLab itself(?) protected it. Now we show `(email protected, possibly DPO@gitlab.com)` instead. That email is on the page currently so that's why it has been chosen.
