### PR TITLE
Fix Aetna Privacy Policy selectors

### DIFF
--- a/declarations/Aetna.json
+++ b/declarations/Aetna.json
@@ -5,10 +5,13 @@
     "Privacy Policy": {
       "fetch": "https://www.aetna.com/legal-notices/privacy/web-privacy.html",
       "select": [
-        ".responsivegrid .body__copy",
-        ".component.container",
-        ".bodytext + .accordion + .text"
-      ]
+        "#content__main > .responsivegrid"
+      ],
+      "remove": [
+        ".breadcrumb-wrapper",
+        ".pageherobanner"
+      ],
+      "executeClientScripts": true
     }
   }
 }


### PR DESCRIPTION
Fixes #1014

## What changed

The Aetna privacy page (`/legal-notices/privacy/web-privacy.html`) was restructured from a flat layout to a tabbed AEM (Adobe Experience Manager) layout. Two of the three original CSS selectors no longer match any elements:

| Selector | Status |
|---|---|
| `.responsivegrid .body__copy` | Still matches (partial content only) |
| `.component.container` | **Broken** — 0 matches |
| `.bodytext + .accordion + .text` | **Broken** — 0 matches |

The privacy content is now organized into three tab panels ("Web and mobile", "Text messages", "Notices by plan") inside `#content__main > .responsivegrid`.

## Changes

- **Replaced selectors** with `#content__main > .responsivegrid`, which captures all three tab panels of privacy content
- **Added `remove`** for `.breadcrumb-wrapper` and `.pageherobanner` to exclude navigation breadcrumbs and the hero banner from the tracked content
- **Added `executeClientScripts: true`** because the site uses Incapsula bot protection, which serves a challenge page to non-browser HTTP clients — the OTA engine needs a headless browser to fetch the actual content

## Verification

Tested with Playwright against the live page. The new selector matches 1 element containing ~67,000 characters of privacy policy text across all three tab sections.

---

🇺🇸 Reid Wiseman — Commander
🇺🇸 Victor Glover — Pilot
🇺🇸 Christina Koch — Mission Specialist
🇨🇦 Jeremy Hansen — Mission Specialist

Artemis II. Privacy is a human right — on this planet and beyond it.